### PR TITLE
implement list.index

### DIFF
--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -889,6 +889,32 @@ def impl_copy(l):
         return impl
 
 
+@overload_method(types.ListType, 'index')
+def impl_index(l, item, start=None, end=None):
+    if not isinstance(l, types.ListType):
+        return
+    itemty = l.item_type
+
+    def check_arg(arg, name):
+        if not (arg is None
+                or arg in types.signed_domain
+                or isinstance(arg, (types.Omitted, types.NoneType))):
+            raise TypingError("{} argument for index must be a signed integer"
+                              .format(name))
+    check_arg(start, "start")
+    check_arg(end, "end")
+
+    def impl(l, item, start=None, end=None):
+        casteditem = _cast(item, itemty)
+        for i in handle_slice(l, slice(start, end, 1)):
+            if l[i] == casteditem:
+                return i
+        else:
+            raise ValueError("item not in list")
+
+    return impl
+
+
 @lower_builtin('getiter', types.ListType)
 def impl_list_getiter(context, builder, sig, args):
     """Implement iter(List).

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -86,6 +86,8 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         # not equal
         new[-1] = 42
         self.assertNotEqual(l, new)
+        # index
+        self.assertEqual(l.index(15), 4)
 
     def test_compiled(self):
         @njit

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -104,6 +104,11 @@ def _ne(t, o):
     return t != o
 
 
+@njit
+def _index(l, item, start, end):
+    return l.index(item, start, end)
+
+
 def _from_meminfo_ptr(ptr, listtype):
     return List(meminfo=ptr, lsttype=listtype)
 
@@ -224,6 +229,9 @@ class List(MutableSequence):
 
     def copy(self):
         return _copy(self)
+
+    def index(self, item, start=None, stop=None):
+        return _index(self, item, start, stop)
 
 
 # XXX: should we have a better way to classmethod


### PR DESCRIPTION
This almost replicates cpython behaviour. The big difference is, that
the defaults for the start and end arguments are None rather than 0 and
MAX_INT64 (or maybe MAX_INT32?!). I wasn't sure where to obtain these
values in a platform independent way, but this could probably be changed
quite easily.
