### PR TITLE
fix extending self

### DIFF
--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -36,6 +36,7 @@ from numba.typedobjectutils import (_as_bytes,
                                     _get_incref_decref,
                                     _get_equal,
                                     _container_get_data,
+                                    _container_get_meminfo,
                                     )
 
 
@@ -200,6 +201,15 @@ def _list_set_method_table(typingctx, lp, itemty):
         builder.call(setmethod_fn, [dp, vtable])
 
     return sig, codegen
+
+
+@lower_builtin(operator.is_, types.ListType, types.ListType)
+def list_is(context, builder, sig, args):
+    a_meminfo = _container_get_meminfo(context, builder, sig.args[0], args[0])
+    b_meminfo = _container_get_meminfo(context, builder, sig.args[1], args[1])
+    ma = builder.ptrtoint(a_meminfo, cgutils.intp_t)
+    mb = builder.ptrtoint(b_meminfo, cgutils.intp_t)
+    return builder.icmp_signed('==', ma, mb)
 
 
 def _call_list_free(context, builder, ptr):
@@ -792,13 +802,21 @@ def impl_extend(l, iterable):
     if not isinstance(iterable, types.IterableType):
         raise TypingError("extend argument must be iterable")
 
-    itemty = l.item_type
+    if isinstance(iterable, types.ListType):
+        def impl(l, iterable):
+            # guard against l.extend(l)
+            if l is iterable:
+                iterable = iterable.copy()
+            for i in iterable:
+                l.append(i)
 
-    def impl(l, iterable):
-        for i in iterable:
-            l.append(_cast(i, itemty))
+        return impl
+    else:
+        def impl(l, iterable):
+            for i in iterable:
+                l.append(i)
 
-    return impl
+        return impl
 
 
 @overload_method(types.ListType, 'insert')

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -289,6 +289,52 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         )
 
 
+class TestExtend(MemoryLeakMixin, TestCase):
+
+    def test_extend_other(self):
+        @njit
+        def impl(other):
+            l = List.empty_list(types.int32)
+            for x in range(10):
+                l.append(x)
+            l.extend(other)
+            return l
+
+        other = List.empty_list(types.int32)
+        for x in range(10):
+            other.append(x)
+
+        expected = impl.py_func(other)
+        got = impl(other)
+        self.assertEqual(expected, got)
+
+    def test_extend_self(self):
+        @njit
+        def impl():
+            l = List.empty_list(types.int32)
+            for x in range(10):
+                l.append(x)
+            l.extend(l)
+            return l
+
+        expected = impl.py_func()
+        got = impl()
+        self.assertEqual(expected, got)
+
+    def test_extend_tuple(self):
+        @njit
+        def impl():
+            l = List.empty_list(types.int32)
+            for x in range(10):
+                l.append(x)
+            l.extend((100,200,300))
+            return l
+
+        expected = impl.py_func()
+        got = impl()
+        self.assertEqual(expected, got)
+
+
 class TestListRefctTypes(MemoryLeakMixin, TestCase):
 
     @skip_py2

--- a/numba/typedobjectutils.py
+++ b/numba/typedobjectutils.py
@@ -88,6 +88,14 @@ def _container_get_data(context, builder, container_ty, c):
     return conatainer_struct.data
 
 
+def _container_get_meminfo(context, builder, container_ty, c):
+    """Helper to get the meminfo for a container
+    """
+    ctor = cgutils.create_struct_proxy(container_ty)
+    conatainer_struct = ctor(context, builder, value=c)
+    return conatainer_struct.meminfo
+
+
 def _get_incref_decref(context, module, datamodel, container_type):
     assert datamodel.contains_nrt_meminfo()
 

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -451,6 +451,9 @@ class SetEntry(Type):
 class ListType(IterableType):
     """List type
     """
+
+    mutable = True
+
     def __init__(self, itemty):
         assert not isinstance(itemty, TypeRef)
         itemty = unliteral(itemty)


### PR DESCRIPTION
The code `l.extend(l)` wasn't working properly. What was needed, is a
defensive copy in case you try to extend the list with itself. The
problem with that was, that the `is` operator wasn't implemented for the
typed-list yet. So, this commit fixes the `is` operator for the typed
list and uses that to implement the defensive copy in case of self
referential extension. Tests included.