### PR TITLE
Typed list fix type inference

### DIFF
--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -524,6 +524,22 @@ class TestComparisons(MemoryLeakMixin, TestCase):
         )
 
 
+class TestListInferred(TestCase):
+
+    def test_simple_refine(self):
+        @njit
+        def foo():
+            l = List()
+            l.append(1)
+            return l
+
+        expected = foo.py_func()
+        got = foo()
+        self.assertEqual(expected, got)
+        self.assertEqual(list(got), [1])
+        self.assertEqual(typeof(got).item_type, typeof(1))
+
+
 class TestListRefctTypes(MemoryLeakMixin, TestCase):
 
     @skip_py2

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -469,7 +469,7 @@ class ListType(IterableType):
         super(ListType, self).__init__(name)
 
     def is_precise(self):
-        return isinstance(self.item_type, Undefined),
+        return not isinstance(self.item_type, Undefined)
 
     @property
     def iterator_type(self):

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -636,7 +636,7 @@ class _OverloadAttributeTemplate(AttributeTemplate):
             sig_args = (typ,)
             sig_kws = {}
             typing_context = context.typing_context
-            disp = cls._get_dispatcher(typing_context, typ, attr, sig_args, sig_kws)
+            disp, sig_args = cls._get_dispatcher(typing_context, typ, attr, sig_args, sig_kws)
             disp_type = types.Dispatcher(disp)
             sig = disp_type.get_call_type(typing_context, sig_args, sig_kws)
             call = context.get_function(disp_type, sig)
@@ -657,19 +657,23 @@ class _OverloadAttributeTemplate(AttributeTemplate):
             if pyfunc is None:
                 # No implementation => fail typing
                 cls._impl_cache[cache_key] = None
-                return
+                return None, None
+            elif isinstance(pyfunc, tuple):
+                # The implementation returned a signature that the type-inferencer
+                # should be using.
+                sig, pyfunc = pyfunc
+                sig_args = sig.args
+                cache_key = None            # don't cache
 
             from numba import jit
             disp = cls._impl_cache[cache_key] = jit(nopython=True)(pyfunc)
-        return disp
+        return disp, sig_args
 
     def _resolve_impl_sig(self, typ, attr, sig_args, sig_kws):
         """
         Compute the actual implementation sig for the given formal argument types.
         """
-        disp = self._get_dispatcher(self.context, typ, attr, sig_args, sig_kws)
-        if disp is None:
-            return None
+        disp, sig_args = self._get_dispatcher(self.context, typ, attr, sig_args, sig_kws)
 
         # Compile and type it for the given types
         disp_type = types.Dispatcher(disp)
@@ -701,7 +705,7 @@ class _OverloadMethodTemplate(_OverloadAttributeTemplate):
         def method_impl(context, builder, sig, args):
             typ = sig.args[0]
             typing_context = context.typing_context
-            disp = cls._get_dispatcher(typing_context, typ, attr, sig.args, {})
+            disp, sig_args = cls._get_dispatcher(typing_context, typ, attr, sig.args, {})
             disp_type = types.Dispatcher(disp)
             sig = disp_type.get_call_type(typing_context, sig.args, {})
             call = context.get_function(disp_type, sig)


### PR DESCRIPTION
This commit does three things:

To begin with, there were actually two severe bugs in `is_prceise`.
First, the negation was missing and secondly the trailing comma meant
that a tuple was being returned. Thus, a list would have always been
deemed to be precise, if there had been any tests for it.

Then, add a simple test to check if refinement works within and outside
of a jit context.

Lastly, After fixing the refinement of the typed-list in a jit context,
it turned out that there is an issue with `overload_method`. The issue
is that, in case of calling an overloaded method on an imprecise
container type, e.g.  typed-list, a function with `overload_method` must
refine the type and return a tuple of the signature that the
implementation should have had and the implementation. While `overload`
does have support for receiving such a tuple, `overload_method` does not
and instead an error regarding a tuple not being callable is raised.
This is fixed now too.