### PR TITLE
remove equals from method table

### DIFF
--- a/numba/_listobject.h
+++ b/numba/_listobject.h
@@ -3,11 +3,9 @@
 #ifndef NUMBA_LIST_H
 #define NUMBA_LIST_H
 
-typedef int (*list_item_comparator_t)(const char *lhs, const char *rhs);
 typedef void (*list_refcount_op_t)(const void*);
 
 typedef struct {
-    list_item_comparator_t    item_equal;
     list_refcount_op_t       item_incref;
     list_refcount_op_t       item_decref;
 } list_type_based_methods_table;

--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -158,7 +158,6 @@ def _list_set_method_table(typingctx, lp, itemty):
 
     def codegen(context, builder, sig, args):
         vtablety = ir.LiteralStructType([
-            ll_voidptr_type,  # equal
             ll_voidptr_type,  # item incref
             ll_voidptr_type,  # item decref
         ])
@@ -174,20 +173,14 @@ def _list_set_method_table(typingctx, lp, itemty):
         dp = args[0]
         vtable = cgutils.alloca_once(builder, vtablety, zfill=True)
 
-        # install key incref/decref
-        item_equal_ptr = cgutils.gep_inbounds(builder, vtable, 0, 0)
-        item_incref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 1)
-        item_decref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 2)
+        # install item incref/decref
+        item_incref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 0)
+        item_decref_ptr = cgutils.gep_inbounds(builder, vtable, 0, 1)
 
         dm_item = context.data_model_manager[itemty.instance_type]
         if dm_item.contains_nrt_meminfo():
-            equal = _get_equal(context, builder.module, dm_item, 'list')
             item_incref, item_decref = _get_incref_decref(
                 context, builder.module, dm_item, "list"
-            )
-            builder.store(
-                builder.bitcast(equal, item_equal_ptr.type.pointee),
-                item_equal_ptr,
             )
             builder.store(
                 builder.bitcast(item_incref, item_incref_ptr.type.pointee),


### PR DESCRIPTION
This commit removed the item equals method from the internal method
table. The equals method is an artifact that remained from copying from
the typed-dict implementation. There it is needed, because indexing can
be done with arbitrary key types and we need to be able to compare keys
during insert and retrieval. Thus, the equals method is used in the
C level code. For the list however, the equals method from the method
table was never used in the c level code, simply because it was never
needed there. Methods that do require a comparison of items such as
count, remove and equals can (and do) do the comparison at the compiler
level. Importantly however, enforcing that the items be comparable via
an equals methods meant that types which are not comparable---such as
jitclasses---could not be stored in the list and the initialization of
the list failed in such cases, since the method table could not be
setup. Now, they could be stored in principle.

As a second step, it probably makes sense to implement a guard function
that checks if a specific item type is comparable and then to use that
guard in any list methods that require this, such as count, remove and
equals.