### PR TITLE
implement deeper compare

### DIFF
--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -1331,17 +1331,6 @@ class TestEqualNotEqual(MemoryLeakMixin, TestCase):
 
         self.assertEqual(foo(), (False, True))
 
-    def test_list_multiple_not_equal_other_type(self):
-        @njit
-        def foo(o):
-            t = listobject.new_list(int32)
-            for i in range(10):
-                t.append(i)
-            return t == o, t != o
-
-        self.assertEqual(foo(1), (False, True))
-        self.assertEqual(foo((1,)), (False, True))
-
 
 class TestIter(MemoryLeakMixin, TestCase):
     """Test list iter. """

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -2,17 +2,24 @@ from __future__ import print_function, absolute_import, division
 
 from itertools import product
 
-import numpy as np
-
 from numba import njit
 from numba import int32, types
 from numba.typed import List, Dict
 from numba.utils import IS_PY3
+from numba.errors import TypingError
 from .support import TestCase, MemoryLeakMixin, unittest
 
 from numba.unsafe.refcount import get_refcount
 
 skip_py2 = unittest.skipUnless(IS_PY3, reason='not supported in py2')
+
+
+def to_tl(l):
+    """ Convert cpython list to typed-list. """
+    tl = List.empty_list(int32)
+    for k in l:
+        tl.append(k)
+    return tl
 
 
 class TestTypedList(MemoryLeakMixin, TestCase):
@@ -173,11 +180,6 @@ class TestTypedList(MemoryLeakMixin, TestCase):
             self.assertEqual(rl_, list(tl_))
             return rl_, tl_
 
-        def to_tl(l):
-            tl = List.empty_list(int32)
-            for k in l:
-                tl.append(k)
-            return tl
 
         ### Simple slicing ###
 
@@ -312,12 +314,6 @@ class TestTypedList(MemoryLeakMixin, TestCase):
             self.assertEqual(rl_, list(tl_))
             return rl_, tl_
 
-        def to_tl(l):
-            tl = List.empty_list(int32)
-            for k in l:
-                tl.append(k)
-            return tl
-
         # define the ranges
         start_range = list(range(-20, 30))
         stop_range = list(range(-20, 30))
@@ -423,6 +419,109 @@ class TestExtend(MemoryLeakMixin, TestCase):
         self.assertEqual(expected, got)
 
 
+@njit
+def cmp(a, b):
+    return a < b, a <= b, a == b, a != b, a >= b, a > b
+
+
+class TestComparisons(MemoryLeakMixin, TestCase):
+
+    def _cmp_dance(self, expected, pa, pb, na, nb):
+        # interpreter with regular list
+        self.assertEqual(cmp.py_func(pa, pb), expected)
+
+        # interpreter with typed-list
+        py_got = cmp.py_func(na, nb)
+        self.assertEqual(py_got, expected)
+
+        # compiled with typed-list
+        jit_got = cmp(na, nb)
+        self.assertEqual(jit_got, expected)
+
+    def test_empty_vs_empty(self):
+        pa, pb = [], []
+        na, nb = to_tl(pa), to_tl(pb)
+        expected = False, True, True, False, True, False
+        self._cmp_dance(expected, pa, pb, na, nb)
+
+    def test_empty_vs_singleton(self):
+        pa, pb = [], [0]
+        na, nb = to_tl(pa), to_tl(pb)
+        expected = True, True, False, True, False, False
+        self._cmp_dance(expected, pa, pb, na, nb)
+
+    def test_singleton_vs_empty(self):
+        pa, pb = [0], []
+        na, nb = to_tl(pa), to_tl(pb)
+        expected = False, False, False, True, True, True
+        self._cmp_dance(expected, pa, pb, na, nb)
+
+    def test_singleton_vs_singleton_equal(self):
+        pa, pb = [0], [0]
+        na, nb = to_tl(pa), to_tl(pb)
+        expected = False, True, True, False, True, False
+        self._cmp_dance(expected, pa, pb, na, nb)
+
+    def test_singleton_vs_singleton_less_than(self):
+        pa, pb = [0], [1]
+        na, nb = to_tl(pa), to_tl(pb)
+        expected = True, True, False, True, False, False
+        self._cmp_dance(expected, pa, pb, na, nb)
+
+    def test_singleton_vs_singleton_greater_than(self):
+        pa, pb = [1], [0]
+        na, nb = to_tl(pa), to_tl(pb)
+        expected = False, False, False, True, True, True
+        self._cmp_dance(expected, pa, pb, na, nb)
+
+    def test_equal(self):
+        pa, pb = [1, 2, 3], [1, 2, 3]
+        na, nb = to_tl(pa), to_tl(pb)
+        expected = False, True, True, False, True, False
+        self._cmp_dance(expected, pa, pb, na, nb)
+
+    def test_first_shorter(self):
+        pa, pb = [1, 2], [1, 2, 3]
+        na, nb = to_tl(pa), to_tl(pb)
+        expected = True, True, False, True, False, False
+        self._cmp_dance(expected, pa, pb, na, nb)
+
+    def test_second_shorter(self):
+        pa, pb = [1, 2, 3], [1, 2]
+        na, nb = to_tl(pa), to_tl(pb)
+        expected = False, False, False, True, True, True
+        self._cmp_dance(expected, pa, pb, na, nb)
+
+    def test_first_less_than(self):
+        pa, pb = [1, 2, 2], [1, 2, 3]
+        na, nb = to_tl(pa), to_tl(pb)
+        expected = True, True, False, True, False, False
+        self._cmp_dance(expected, pa, pb, na, nb)
+
+    def test_first_greater_than(self):
+        pa, pb = [1, 2, 3], [1, 2, 2]
+        na, nb = to_tl(pa), to_tl(pb)
+        expected = False, False, False, True, True, True
+        self._cmp_dance(expected, pa, pb, na, nb)
+
+    def test_typing_mimatch(self):
+        self.disable_leak_check()
+        l = to_tl([1, 2, 3])
+
+        with self.assertRaises(TypingError) as raises:
+            cmp.py_func(l, 1)
+        self.assertIn(
+            "list can only be compared to list",
+            str(raises.exception),
+        )
+        with self.assertRaises(TypingError) as raises:
+            cmp(l, 1)
+        self.assertIn(
+            "list can only be compared to list",
+            str(raises.exception),
+        )
+
+
 class TestListRefctTypes(MemoryLeakMixin, TestCase):
 
     @skip_py2
@@ -526,20 +625,19 @@ class TestListRefctTypes(MemoryLeakMixin, TestCase):
 
         expected = foo.py_func()
         got = foo()
-        got == expected
         self.assertEqual(expected, got)
 
-    @skip_py2
-    def test_array_as_item_in_list(self):
-        nested_type = types.Array(types.float64, 1, 'C')
-        @njit
-        def foo():
-            l = List.empty_list(nested_type)
-            a = np.zeros((1,))
-            l.append(a)
-            return l
+    #@skip_py2
+    #def test_array_as_item_in_list(self):
+    #    nested_type = types.Array(types.float64, 1, 'C')
+    #    @njit
+    #    def foo():
+    #        l = List.empty_list(nested_type)
+    #        a = np.zeros((1,))
+    #        l.append(a)
+    #        return l
 
-        expected = foo.py_func()
-        got = foo()
-        got == expected
-        self.assertEqual(expected, got)
+    #    expected = foo.py_func()
+    #    got = foo()
+    #    got == expected
+    #    self.assertEqual(expected, got)

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -110,6 +110,26 @@ def _ne(t, o):
 
 
 @njit
+def _lt(t, o):
+    return t < o
+
+
+@njit
+def _le(t, o):
+    return t <= o
+
+
+@njit
+def _gt(t, o):
+    return t > o
+
+
+@njit
+def _ge(t, o):
+    return t >= o
+
+
+@njit
 def _index(l, item, start, end):
     return l.index(item, start, end)
 
@@ -184,6 +204,18 @@ class List(MutableSequence):
 
     def __ne__(self, other):
         return _ne(self, other)
+
+    def __lt__(self, other):
+        return _lt(self, other)
+
+    def __le__(self, other):
+        return _le(self, other)
+
+    def __gt__(self, other):
+        return _gt(self, other)
+
+    def __ge__(self, other):
+        return _ge(self, other)
 
     def append(self, item):
         if not self._typed:


### PR DESCRIPTION
This implements the operators <, <=, > and >= for the typed list. Lists
with nested Numpy arrays can no longer be compared. This doesn't work in
cpython also, so it isn't too bad. The error message is a bit cryptic
however as this fails during lowering. Also, we now raise a TypingError
if the thing being compared to is not also a typed-list. The problem
here is that if we always just return False for a type-mismatch, then
both a < b and a > b will be False, which doesn't make any sense.  This
might be a bit over-restrictive however, but should be fine for most
 use-cases.